### PR TITLE
Update Content for Data Literacy Documentation

### DIFF
--- a/courseware/data_literacy/course_materials/how_to_use.md
+++ b/courseware/data_literacy/course_materials/how_to_use.md
@@ -6,3 +6,17 @@ parent: Course Materials
 grand_parent: Data Literacy with Data Commons
 great_grand_parent: Courseware
 ---
+
+## How To Use
+
+The curriculum is organized in self-contained modules. Instructors (and students) are welcome to consume or work through any of the modules or the components within any module. Each [module](modules.html) is available as a detailed document with several pedagogical notes, objectives and an outline/table of contents to allow easy navigation.
+
+To find what you may be looking for, or to use any content in your own courses/curriculum, we recommend the following approach:
+
+1. Read our [Overview page](../overview.html) and [FAQs page](../faqs.html) to familiarize yourself with the curriculum objectives which may explain our curriculum design choices.
+
+2. Navigate to the [Key Themes pages](key_themes.html). It lists several key themes along with some pointers to specific modules which have the complete details.
+
+3. Navigate to the [Modules page](modules.html). For each module, we describe its goal and include its table of contents. If you find what you are looking for (e.g. search "Categorical vs Numeric Variables" and you should find yourself at the second module), you can then access the module directly for the content.
+
+4. If you do not find the topic/concept you are looking for, please email us at [courses@datacommons.org](mailto:courses@datacommons.org) with suggestions about topics/concepts to add. If you would like to contribute to this endeavor, please do reach out at [courses@datacommons.org](mailto:courses@datacommons.org) and help us add more content.

--- a/courseware/data_literacy/course_materials/index.md
+++ b/courseware/data_literacy/course_materials/index.md
@@ -6,3 +6,16 @@ parent: Data Literacy with Data Commons
 grand_parent: Courseware
 has_children: true
 ---
+
+# Course Materials
+
+The Data Literacy course curriculum is structured into a series of modules, which can be explored in the following ways:
+
+- [Key Themes](key_themes.html) lists several key themes along with some pointers to specific modules which have the complete details. You can use search (Ctrl + F) on this page to search for a term or topic you are interested in.
+- [Modules](modules.html) describes and links all available (and planned) modules along with their tables of contents. You can search for topics here as well and/or access the modules directly to explore.
+- [How to Use](how_to_use.html) describes a general (recommended) process for navigating these pages and the course content.
+
+If you do not find the topic/concept you are looking for, please email us at [courses@datacommons.org](mailto:courses@datacommons.org) with suggestions about topics/concepts to add. If you would like to contribute to this endeavor, please do reach out at [courses@datacommons.org](mailto:courses@datacommons.org) and help us add more content.
+
+
+

--- a/courseware/data_literacy/course_materials/key_themes.md
+++ b/courseware/data_literacy/course_materials/key_themes.md
@@ -6,3 +6,62 @@ parent: Course Materials
 grand_parent: Data Literacy with Data Commons
 great_grand_parent: Courseware
 ---
+
+# Key Themes
+{:#key-themes}
+
+- **Data and Modeling Overview** [[Data and Modeling Overview](https://docs.google.com/document/d/e/2PACX-1vTOMdb9IwrL14be61bxeIaAwOuBrueAELoRJNceE8FLlYP2QE8yEr2px2fGnupUWZAfzq_i00Dco3JJ/pub)]
+  - What it means to ‘model’ a phenomenon
+  - What is a variable
+  - What is a measurement
+    - Observation (direct) vs estimation (indirect)
+    - Interpolation as an instance of estimation (indirect)
+    - Introduce concepts such as sampling vs complete population-level observations
+      - Types of sampling e.g. random, systematic, cluster, etc.
+- **Basic Data Analysis**
+  - Summary Statistics [[Data and Modeling Overview](https://docs.google.com/document/d/e/2PACX-1vTOMdb9IwrL14be61bxeIaAwOuBrueAELoRJNceE8FLlYP2QE8yEr2px2fGnupUWZAfzq_i00Dco3JJ/pub), [Deep Dive into Data “Set”](https://docs.google.com/document/d/e/2PACX-1vRSLiNxqIQJP3Tp-6eLdz_-Iv5nPp_Q_yS2cY1SbF2wrNbGRsQS26s32fd1gZYrVyarnH8R364G3I3N/pub)]
+    - Measures of central tendency and their benefits/drawbacks
+      - E.g. Mean, median, mode
+    - Measures of variability and their benefits/drawbacks
+      - E.g. Variation, range, standard deviation
+    - Discuss the limitations of summary statistics with examples
+      - E.g. Anscombe Quartet
+  - Aggregations
+    - When and why do aggregations make sense or are necessary [[Relating Data “Sets”](https://docs.google.com/document/d/e/2PACX-1vQnJHyjrK85SLlSmlFwzoAi2bA8javVv__apXmeq_N_e4LFmqyB7x1I-ghM2Y0PGXy0K8RWd2I_lny7/pub), [Mapping](https://docs.google.com/document/d/e/2PACX-1vQ947FunXunwK32SQeKQHSi7F8P97mQusHh4WjgMKtnp-y_MX_sAGosKUDgX7xaKK1QdpMQCsPXaJKV/pub)]
+    - How to aggregate two data sets into one [[Relating Data “Sets”](https://docs.google.com/document/d/e/2PACX-1vQnJHyjrK85SLlSmlFwzoAi2bA8javVv__apXmeq_N_e4LFmqyB7x1I-ghM2Y0PGXy0K8RWd2I_lny7/pub)]
+    - How to aggregate data sets between levels of granularity [[Mapping](https://docs.google.com/document/d/e/2PACX-1vQ947FunXunwK32SQeKQHSi7F8P97mQusHh4WjgMKtnp-y_MX_sAGosKUDgX7xaKK1QdpMQCsPXaJKV/pub)]
+  - Outliers [[Plotting/Graphing](https://docs.google.com/document/d/e/2PACX-1vQUn3ShN4vdfeXw5o-nXkMHWu9Q6DoyO1Ihk1V0QQ6J3ZaRSB9KhPcgymjvZYA95G86tLQGnsWHNPzd/pub)]
+    - Why we care about outliers
+    - How to spot and handle outliers
+- **Techniques for Data Visualization** [[Plotting/Graphing](https://docs.google.com/document/d/e/2PACX-1vQUn3ShN4vdfeXw5o-nXkMHWu9Q6DoyO1Ihk1V0QQ6J3ZaRSB9KhPcgymjvZYA95G86tLQGnsWHNPzd/pub)]
+  - Plotting vs graphing
+  - Why we visualize data
+  - Types of plots
+    - Scatter, line, map, bar, histogram, etc.
+  - How to visualize 1-D vs 2-D vs N-D Data
+- **Techniques for Statistical Modeling**
+  - Distributions [[Plotting/Graphing](https://docs.google.com/document/d/e/2PACX-1vQUn3ShN4vdfeXw5o-nXkMHWu9Q6DoyO1Ihk1V0QQ6J3ZaRSB9KhPcgymjvZYA95G86tLQGnsWHNPzd/pub)(Advanced Topic)]
+    - Theoretical vs empirical (i.e. probability distributions vs frequency distributions)
+    - Normal/Gaussian distribution
+      - Properties of the normal distribution
+      - When it is appropriate to model using the normal distribution
+    - Exponential distribution
+    - Other distributions
+      - Bernoulli
+      - Binomial
+  - Correlations [[Correlations](https://docs.google.com/document/d/e/2PACX-1vTKng32E3mwC6whbEXoFw9UyTHMSH9HH-ySoZ-lRlzB0DTXc72i4VmXuYj0a9LjkakQ-w84IkClQM4q/pub)]
+    - Linear vs quadratic vs exponential
+    - Degree and direction of correlation
+    - How to identify correlations
+      - Visually (e.g. scatter plot)
+      - Numerically (e.g. correlation coefficient)
+    - Common pitfalls such as overgeneralization, Simpson’s paradox, etc.
+    - Correlation vs. causation
+- **Data Science in the Real World** [[Data and Modeling Overview](https://docs.google.com/document/d/e/2PACX-1vTOMdb9IwrL14be61bxeIaAwOuBrueAELoRJNceE8FLlYP2QE8yEr2px2fGnupUWZAfzq_i00Dco3JJ/pub)]
+  - Lies, damn lies and statistics
+    - Manipulative visuals
+    - Manipulative statistics
+  - Cognitive biases
+    - Survivorship bias
+    - False causality fallacy
+    - Other biases

--- a/courseware/data_literacy/course_materials/modules.md
+++ b/courseware/data_literacy/course_materials/modules.md
@@ -7,80 +7,14 @@ grand_parent: Data Literacy with Data Commons
 great_grand_parent: Courseware
 ---
 
-# Course Material
-
-This page provides an outline of the topics covered in the [modules](course_materials.html#modules) of our "Data Literacy with Data Commons" course materials. Use search (Ctrl + F) on this page to search for a term or topic you are interested in.
-
-The page is split into two sections:
-
-- [Key Themes](#key-themes) lists several key themes along with some pointers to specific modules which have the complete details
-- [Topics by Module](#topics-by-module) shows the table of contents for each module
-
-If you do not find the topic/concept you are looking for, please email us at [courses@datacommons.org](mailto:courses@datacommons.org) with suggestions about topics/concepts to add. If you would like to contribute to this endeavor, please do reach out at [courses@datacommons.org](mailto:courses@datacommons.org) and help us add more content.
-
-## Key Themes
-{:#key-themes}
-
-- **Data and Modeling Overview** [[Data and Modeling Overview](https://docs.google.com/document/d/e/2PACX-1vTOMdb9IwrL14be61bxeIaAwOuBrueAELoRJNceE8FLlYP2QE8yEr2px2fGnupUWZAfzq_i00Dco3JJ/pub)]
-  - What it means to ‘model’ a phenomenon
-  - What is a variable
-  - What is a measurement
-    - Observation (direct) vs estimation (indirect)
-    - Interpolation as an instance of estimation (indirect)
-    - Introduce concepts such as sampling vs complete population-level observations
-      - Types of sampling e.g. random, systematic, cluster, etc.
-- **Basic Data Analysis**
-  - Summary Statistics [[Data and Modeling Overview](https://docs.google.com/document/d/e/2PACX-1vTOMdb9IwrL14be61bxeIaAwOuBrueAELoRJNceE8FLlYP2QE8yEr2px2fGnupUWZAfzq_i00Dco3JJ/pub), [Deep Dive into Data “Set”](https://docs.google.com/document/d/e/2PACX-1vRSLiNxqIQJP3Tp-6eLdz_-Iv5nPp_Q_yS2cY1SbF2wrNbGRsQS26s32fd1gZYrVyarnH8R364G3I3N/pub)]
-    - Measures of central tendency and their benefits/drawbacks
-      - E.g. Mean, median, mode
-    - Measures of variability and their benefits/drawbacks
-      - E.g. Variation, range, standard deviation
-    - Discuss the limitations of summary statistics with examples
-      - E.g. Anscombe Quartet
-  - Aggregations
-    - When and why do aggregations make sense or are necessary [[Relating Data “Sets”](https://docs.google.com/document/d/e/2PACX-1vQnJHyjrK85SLlSmlFwzoAi2bA8javVv__apXmeq_N_e4LFmqyB7x1I-ghM2Y0PGXy0K8RWd2I_lny7/pub), [Mapping](https://docs.google.com/document/d/e/2PACX-1vQ947FunXunwK32SQeKQHSi7F8P97mQusHh4WjgMKtnp-y_MX_sAGosKUDgX7xaKK1QdpMQCsPXaJKV/pub)]
-    - How to aggregate two data sets into one [[Relating Data “Sets”](https://docs.google.com/document/d/e/2PACX-1vQnJHyjrK85SLlSmlFwzoAi2bA8javVv__apXmeq_N_e4LFmqyB7x1I-ghM2Y0PGXy0K8RWd2I_lny7/pub)]
-    - How to aggregate data sets between levels of granularity [[Mapping](https://docs.google.com/document/d/e/2PACX-1vQ947FunXunwK32SQeKQHSi7F8P97mQusHh4WjgMKtnp-y_MX_sAGosKUDgX7xaKK1QdpMQCsPXaJKV/pub)]
-  - Outliers [[Plotting/Graphing](https://docs.google.com/document/d/e/2PACX-1vQUn3ShN4vdfeXw5o-nXkMHWu9Q6DoyO1Ihk1V0QQ6J3ZaRSB9KhPcgymjvZYA95G86tLQGnsWHNPzd/pub)]
-    - Why we care about outliers
-    - How to spot and handle outliers
-- **Techniques for Data Visualization** [[Plotting/Graphing](https://docs.google.com/document/d/e/2PACX-1vQUn3ShN4vdfeXw5o-nXkMHWu9Q6DoyO1Ihk1V0QQ6J3ZaRSB9KhPcgymjvZYA95G86tLQGnsWHNPzd/pub)]
-  - Plotting vs graphing
-  - Why we visualize data
-  - Types of plots
-    - Scatter, line, map, bar, histogram, etc.
-  - How to visualize 1-D vs 2-D vs N-D Data
-- **Techniques for Statistical Modeling**
-  - Distributions [[Plotting/Graphing](https://docs.google.com/document/d/e/2PACX-1vQUn3ShN4vdfeXw5o-nXkMHWu9Q6DoyO1Ihk1V0QQ6J3ZaRSB9KhPcgymjvZYA95G86tLQGnsWHNPzd/pub)(Advanced Topic)]
-    - Theoretical vs empirical (i.e. probability distributions vs frequency distributions)
-    - Normal/Gaussian distribution
-      - Properties of the normal distribution
-      - When it is appropriate to model using the normal distribution
-    - Exponential distribution
-    - Other distributions
-      - Bernoulli
-      - Binomial
-  - Correlations [[Correlations](https://docs.google.com/document/d/e/2PACX-1vTKng32E3mwC6whbEXoFw9UyTHMSH9HH-ySoZ-lRlzB0DTXc72i4VmXuYj0a9LjkakQ-w84IkClQM4q/pub)]
-    - Linear vs quadratic vs exponential
-    - Degree and direction of correlation
-    - How to identify correlations
-      - Visually (e.g. scatter plot)
-      - Numerically (e.g. correlation coefficient)
-    - Common pitfalls such as overgeneralization, Simpson’s paradox, etc.
-    - Correlation vs. causation
-- **Data Science in the Real World** [[Data and Modeling Overview](https://docs.google.com/document/d/e/2PACX-1vTOMdb9IwrL14be61bxeIaAwOuBrueAELoRJNceE8FLlYP2QE8yEr2px2fGnupUWZAfzq_i00Dco3JJ/pub)]
-  - Lies, damn lies and statistics
-    - Manipulative visuals
-    - Manipulative statistics
-  - Cognitive biases
-    - Survivorship bias
-    - False causality fallacy
-    - Other biases
-  
-## Topics Organized By Module
-{:#topics-by-module}
+# Modules
+{:#modules}
 
 **Module 1: [Data Overview](https://docs.google.com/document/d/e/2PACX-1vTOMdb9IwrL14be61bxeIaAwOuBrueAELoRJNceE8FLlYP2QE8yEr2px2fGnupUWZAfzq_i00Dco3JJ/pub)**
+
+This module is meant to serve as the introductory class(es) in a data literacy course. It provides motivation for why data literacy matters, introduces key concepts such as measurements, variables, models, etc., and defines some basic descriptive statistics and data visualization techniques.
+
+_Table of Contents_
 
 - Lies, Damn Lies, and Statistics
 - Why is Data Literacy Important?
@@ -121,6 +55,10 @@ If you do not find the topic/concept you are looking for, please email us at [co
 
 **Module 2: [Deep Dive into Data "Set"](https://docs.google.com/document/d/e/2PACX-1vRSLiNxqIQJP3Tp-6eLdz_-Iv5nPp_Q_yS2cY1SbF2wrNbGRsQS26s32fd1gZYrVyarnH8R364G3I3N/pub)**
 
+Introduces students to the idea of a data “set” as well as some basic terms and statistical measures (e.g. mean, standard deviation, etc.) while highlighting important caveats and takeaways when drawing conclusions from these measures.
+
+_Table of Contents_
+
 - Where Do Data Sets Come From?
 - Examples of Datasets
 - Exploring Datasets
@@ -143,6 +81,10 @@ If you do not find the topic/concept you are looking for, please email us at [co
 - Explore, Analyze and Compare Two Datasets
 
 **Module 3: [Relating Data "Sets"](https://docs.google.com/document/d/e/2PACX-1vQnJHyjrK85SLlSmlFwzoAi2bA8javVv__apXmeq_N_e4LFmqyB7x1I-ghM2Y0PGXy0K8RWd2I_lny7/pub)**
+
+Introduces students to the idea of related data sets and describes how to merge data sets into one large data collection. Real data sets are analyzed in depth to demonstrate the benefits of building a nuanced, complete picture of the world.
+
+_Table of Contents_
 
 - What Are Related Data Sets?
   - Examples of Related Data Sets
@@ -167,6 +109,10 @@ If you do not find the topic/concept you are looking for, please email us at [co
 - Exercise: Where to Live?
 
 **Module 4: [Plotting/Graphing](https://docs.google.com/document/d/e/2PACX-1vQUn3ShN4vdfeXw5o-nXkMHWu9Q6DoyO1Ihk1V0QQ6J3ZaRSB9KhPcgymjvZYA95G86tLQGnsWHNPzd/pub)**
+
+Introduces students to some common plots and graphs and discusses when to use each depending on the data and the context. It also defines and explores various distributions with analysis of their properties and examples from the real world.
+
+_Table of Contents_
 
 - Plot vs. Graph
 - Why Do We Plot?
@@ -194,6 +140,10 @@ If you do not find the topic/concept you are looking for, please email us at [co
   - Binomial
 
 **Module 5: [Correlations](https://docs.google.com/document/d/e/2PACX-1vTKng32E3mwC6whbEXoFw9UyTHMSH9HH-ySoZ-lRlzB0DTXc72i4VmXuYj0a9LjkakQ-w84IkClQM4q/pub)**
+
+Introduces students to the idea of correlation between two variables and describes how to observe, quantify, and label correlations, with a focus on linear correlations. Strategies for distinguishing real correlations from noise are provided and common pitfalls, such as correlation vs causation, are discussed in depth.
+
+_Table of Contents_
 
 - What is Correlation?
   - Linear, Quadratic, and Exponential Correlations
@@ -223,6 +173,9 @@ If you do not find the topic/concept you are looking for, please email us at [co
   
 **Module 6: [Mapping](https://docs.google.com/document/d/e/2PACX-1vQ947FunXunwK32SQeKQHSi7F8P97mQusHh4WjgMKtnp-y_MX_sAGosKUDgX7xaKK1QdpMQCsPXaJKV/pub)**
 
+Introduces students to the idea of geographic data and discusses how to visualize and aggregate geographic data.
+
+_Table of Contents_
 - Examples of Geographic Data
 - Levels of Granularity
   - Latitude/Longitude Coordinates
@@ -242,3 +195,7 @@ If you do not find the topic/concept you are looking for, please email us at [co
   - Aggregation by Something Else?
   - Exercise: Aggregation by You
 - Converting between Types of Granularity
+
+**Module 7: Time Series**
+
+Coming soon!

--- a/courseware/data_literacy/faqs.md
+++ b/courseware/data_literacy/faqs.md
@@ -9,12 +9,12 @@ grand_parent: Courseware
 # Frequently Asked Questions
 
 <div markdown="span" class="alert alert-info" role="alert" style="text-align: center">
-    >> [Access the course materials here](course_materials.html#modules). <<
+    >> [Access the course materials here](course_materials/). <<
 </div>
 
 ## What is it?
 
-A set of [modules](course_materials.html#modules) focusing on several [key concepts](topics.html#key-concepts) focusing on data modeling, analysis, visualization and the (ab)use of data to tell (false) narratives. Each module lists its objectives and builds on a pedagogical narrative around the explanation of key concepts, e.g. the differences between correlations and causation. We extensively use the Data Commons platform to point to _real world_ examples without needing to write a single line of code!  
+A set of [modules](course_materials/modules.html) focusing on several [key concepts](course_materials/key_themes.html) focusing on data modeling, analysis, visualization and the (ab)use of data to tell (false) narratives. Each module lists its objectives and builds on a pedagogical narrative around the explanation of key concepts, e.g. the differences between correlations and causation. We extensively use the Data Commons platform to point to _real world_ examples without needing to write a single line of code!  
 
 All material is provided publicly and free of charge, under a Creative Commons license ([CC BY](https://creativecommons.org/licenses/by/4.0/)).
 
@@ -54,7 +54,7 @@ For the purpose of the Data Literacy, the Data Commons platform becomes an impor
 
 ## What topics are covered?
 
-Take a look at the [topics covered page](topics.html).
+Take a look at the [Key Themes page](course_materials/key_themes.html) or the [Modules page](course_materials/modules.html).
 ## What is not covered?
 
 We note that the curriculum objectives, themes, content and areas of focus are neither exhaustive nor a one size fits all. For example, we do not focus on the ethics of data collection in this curriculum. While these issues are of utmost importance, we chose to focus on a more basic and hands-on approach with the available resources. If you wish to help contribute any themes/topics that would supplement this material, please reach out at [courses@datacommons.org](mailto:courses@datacommons.org) and we would love to work with you.

--- a/courseware/data_literacy/overview.md
+++ b/courseware/data_literacy/overview.md
@@ -13,7 +13,7 @@ grand_parent: Courseware
 "Data Literacy with Data Commons" comprises curriculum/course materials for instructors, students and other practitioners working on or helping others become _data literate_. This includes detailed modules with pedagogical narratives, explanations of key concepts, examples, and suggestions for exercises/projects focused on advancing the _consumption_, _understanding_ and _interpretation_ of data in the contemporary world. In our quest to expand the reach and utility of this material, we assume no background in computer science or programming, thereby removing a key obstacle to many such endeavors.
 
 <div markdown="span" class="alert alert-info" role="alert">
-    For more background about the course, see our [About the Course](about_the_course.html) page.
+    For more background about the course, see our [FAQs](faqs.html) page.
 </div>
 
 ### Objectives
@@ -36,61 +36,6 @@ We suggest only the following prerequisites for this curriculum:
 
 - High-School level Mathematics (basic).
 - High-School level Statistics (basic).
-
-## Modules
-{:#modules}
-
-The curriculum modules are listed below along with the table of contents from each module. Click on the module name and references to access all the content in the module.
-
-<div markdown="span" class="alert alert-info" role="alert">
-   <span class="material-icons md-16">info </span><b>Tip:</b>
-   For a list of topics covered, see the [topics page](topics.html).
-</div>
-
-
-**Module 1: [Data Overview](https://docs.google.com/document/d/e/2PACX-1vTOMdb9IwrL14be61bxeIaAwOuBrueAELoRJNceE8FLlYP2QE8yEr2px2fGnupUWZAfzq_i00Dco3JJ/pub)**
-
-This module is meant to serve as the introductory class(es) in a data literacy course. It provides motivation for why data literacy matters, introduces key concepts such as measurements, variables, models, etc., and defines some basic descriptive statistics and data visualization techniques.
-
-**Module 2: [Deep Dive into Data "Set"](https://docs.google.com/document/d/e/2PACX-1vRSLiNxqIQJP3Tp-6eLdz_-Iv5nPp_Q_yS2cY1SbF2wrNbGRsQS26s32fd1gZYrVyarnH8R364G3I3N/pub)**
-
-Introduces students to the idea of a data “set” as well as some basic terms and statistical measures (e.g. mean, standard deviation, etc.) while highlighting important caveats and takeaways when drawing conclusions from these measures.
-
-**Module 3: [Relating Data "Sets"](https://docs.google.com/document/d/e/2PACX-1vQnJHyjrK85SLlSmlFwzoAi2bA8javVv__apXmeq_N_e4LFmqyB7x1I-ghM2Y0PGXy0K8RWd2I_lny7/pub)**
-
-Introduces students to the idea of related data sets and describes how to merge data sets into one large data collection. Real data sets are analyzed in depth to demonstrate the benefits of building a nuanced, complete picture of the world.
-
-**Module 4: [Plotting/Graphing](https://docs.google.com/document/d/e/2PACX-1vQUn3ShN4vdfeXw5o-nXkMHWu9Q6DoyO1Ihk1V0QQ6J3ZaRSB9KhPcgymjvZYA95G86tLQGnsWHNPzd/pub)**
-
-Introduces students to some common plots and graphs and discusses when to use each depending on the data and the context. It also defines and explores various distributions with analysis of their properties and examples from the real world
-
-**Module 5: [Correlations](https://docs.google.com/document/d/e/2PACX-1vTKng32E3mwC6whbEXoFw9UyTHMSH9HH-ySoZ-lRlzB0DTXc72i4VmXuYj0a9LjkakQ-w84IkClQM4q/pub)**
-
-Introduces students to the idea of correlation between two variables and describes how to observe, quantify, and label correlations, with a focus on linear correlations. Strategies for distinguishing real correlations from noise are provided and common pitfalls, such as correlation vs causation, are discussed in depth.
-  
-**Module 6: [Mapping](https://docs.google.com/document/d/e/2PACX-1vQ947FunXunwK32SQeKQHSi7F8P97mQusHh4WjgMKtnp-y_MX_sAGosKUDgX7xaKK1QdpMQCsPXaJKV/pub)**
-
-Introduces students to the idea of geographic data and discusses how to visualize and aggregate geographic data.
-
-**Module 7: Time Series**
-
-Coming soon!
-
-## How To Use
-
-The curriculum is organized in self-contained modules. Instructors (and students) are welcome to consume or work through any of the modules or the components within any module. Each [module](#modules) is available as a detailed document with several pedagogical notes, objectives and an outline/table of contents to allow easy navigation.
-
-To find what you may be looking for, or to use any content in your own courses/curriculum, we recommend the following approach:
-
-1. Read our [about the course page](about_the_course.html) to familiarize yourself with the curriculum objectives which may explain our curriculum design choices.
-
-2. Navigate to the [key themes section](topics.html#key-themes) below. It lists several key themes along with some pointers to specific modules which have the complete details.
-
-3. Navigate to the [topics by module section](topics.html#topics-by-module) below. For each module, we show the table of contents. If you find what you are looking for (e.g. search "Categorical vs Numeric Variables" and you should find yourself at the second module). You can then access the module itself for the content.
-
-4. Use search (Ctrl + F) on the [topics page](topics.html) to search for a term or topic you are interested in. If found, navigate to the linked module(s) to find the content.
-
-5. If you do not find the topic/concept you are looking for, please email us at [courses@datacommons.org](mailto:courses@datacommons.org) with suggestions about topics/concepts to add. If you would like to contribute to this endeavor, please do reach out at [courses@datacommons.org](mailto:courses@datacommons.org) and help us add more content.
 
 ### Feedback
 


### PR DESCRIPTION
This PR has the following changes:

- Move Modules section from Overview to Modules page
- Move Key Themes section to Key Themes page
- Reword Course Materials landing page language to reflect new structure
- Move How to Use section from overview to its dedicated page
- Update all links to reflect new structure
- Update How to Use section
